### PR TITLE
common.py fix for callsign metadata in radial file header (issue #16)

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="Black">
+    <option name="sdkName" value="hfradarpy" />
+  </component>
   <component name="ProjectRootManager" version="2" project-jdk-name="hfradarpy" project-jdk-type="Python SDK" />
 </project>

--- a/hfradarpy/common.py
+++ b/hfradarpy/common.py
@@ -472,7 +472,11 @@ class fileParser(object):
         line = line.replace("\n", "")  # Strip the new line character from the end of the line
         line_split = line.split(":")
         key = line_split[0]  # save key variable
-        value = line_split[1].strip()  # save value variable and strip whitespace from value
+        if len(line_split) > 1: # save value variable and strip whitespace from valu
+            divider = ":"
+            value = divider.join(line_split[1:]).strip()
+        else:
+            value = line_split[1].strip()
         return key, value
 
     @staticmethod


### PR DESCRIPTION
Callsign metadata information in the header of the radial file was not parsed correctly because that header line included multiple colons.  The _parse_header_line method in common.py has been updated to handle any lines that have multiple colons.